### PR TITLE
Include Neighbor Info in recommended settings

### DIFF
--- a/content/docs/getting-started/recommended-settings.md
+++ b/content/docs/getting-started/recommended-settings.md
@@ -42,4 +42,6 @@ In the Bay Area, we have a few recommendations for configuration:
     * Device Telemetry (iOS)
         * Device Metrics: 6 hour (iOS) / 21,600 seconds (Android)
         * Sensor (Environment) Metrics: 6 hour / 21,600 seconds (Android)
-
+    * Neighbor Info
+        * Set Neighbor Info Enabled to true
+        * Enter default Update interval: 4 hour / 14400 seconds


### PR DESCRIPTION
Added Neighbor Info settings for device configuration.

Without both of these settings, neighbor info will not display in meshview.bayme.sh