### PR TITLE
Include frequency slot in recommended settings

### DIFF
--- a/content/docs/getting-started/recommended-settings.md
+++ b/content/docs/getting-started/recommended-settings.md
@@ -16,6 +16,7 @@ In the Bay Area, we have a few recommendations for configuration:
 * LORA
     * Set region to United States (US)
     * **Preset**: Medium Range Fast
+    * **Frequency slot**: 45 (You may or may not need to set this)
     * **Number of hops for infrastructure node**: 4 (3 is default, up to 5 is ok)
     * **Number of hops for personal/chat node**: 6 (up to 7 is ok if desired)
     * **Ignore MQTT**: Optional: Enable this to ignore traffic that may have been downlinked from MQTT (the internet)


### PR DESCRIPTION
Sometimes the meshtastic app doesn't set the frequency slot correctly for whatever reason so it's good to include this info on the recommended settings page just in case. I ran into this problem and it looks like a few others have too: #24 and #22